### PR TITLE
Add FAQ for how to contribute to the FAQ and expand the file structure answer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@ Unofficial Meteor FAQ
 =====================
 Just answering some common questions that aren’t answered in the [official meteor FAQ](http://www.meteor.com/faq/).
 
+##How do I update this FAQ?
+
+Send Tom an email at xxx (do you want to put your email on the FAQ) or fork the FAQ and send a pull request (we can discuss changes and ideas as part of the pull request).
+
 ##How can I use someone else's javascript in my meteor project?
 
 It depends on how it's packaged. If there's already a smart package, you can use [meteorite](http://possibilities.github.com/meteorite/) to include it. Make sure you check the [atmosphere](http://atmosphere.meteor.com) package repository too.
@@ -63,7 +67,7 @@ Meteor.subscribe('foo', function() {
 The example apps in meteor are very simple, and don’t provide much insight. Here’s my current thinking on the best way to do it: (any suggestions/improvements are very welcome!)
 
 ```bash
-lib/                    # <- any common code for client/server
+lib/                    # <- any common code for client/server. js in lib folders are loaded before other js files.
 lib/environment.js      # <- general configuration
 lib/vendor              # <- common code from someone else
 models/                 # <- definitions of collections and methods on them (could be collections/)
@@ -81,3 +85,12 @@ server/methods.js       # <- Meteor.method definitions
 server.environment.js   # <- configuration of server side packages
 ```
 
+For larger applications, functionality can be broken up into sub-directories which are themselves, organized using the same pattern (and it's one step along the road to forming a smart package).
+
+```bash
+feature-foo/            # <- all functionality related to feature 'foo'
+feature-foo/lib/        # <- common code
+feature-foo/models/     # <- model definitions
+feature-foo/client/     # <- files only sent to the client
+feature-foo/server/     # <- files only available on the server
+```


### PR DESCRIPTION
I put a place holder in the FAQ for how to contribute additional information or comment on the FAQ. It's fairly meta but it was the first question I had when reading the FAQ. I'm expecting you to change that or tell me you don't want that in the FAQ but I thought I'd at least put something in there to make the suggestion. :)

As for file organization, on larger applications, I'm finding that it's easier to keep track of files and to simply see the right files together by organizing in sub-directories based on functionality, then by the standard layout in the FAQ. I haven't fully played around with it to make sure the layout is entirely safe but my quick glance at the Meteor source makes me think this organization will work (and my initial use of it is working). I think at some point there should be some sort of documentation or tutorial on how to migrate functionality from kind of the "quick implementation" phase to the "organized" phase (where you have all the functionality grouped into a single, well organized sub-directory, and finally into the "smart package" phase where that functionality is made reusable and placed into a smart package. I've never taken something through the whole process so this is my first step towards that.
