### PR TITLE
just replaced meteor_bootstrap w/ npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If it's a simple client side JS script, you can include it in `client/lib/` or `
 
 You can get access to node's native require functionality via:
 ```js
-var foo = __meteor_bootstrap__.require('foo');
+var foo = Npm.require('foo');
 ```
 
 Note that this will probably work for you local development, but you may have trouble if you try to use that command when you deploy somewhere, depending on how much control you have over the deployment environment.


### PR DESCRIPTION
also, the line right after that, about trouble using that command in a different environment - is that still true? If it is, would you mind adding a note as to why we might have trouble using that command elsewhere?
Thanks
-Tom
