### PR TITLE
add Table of Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Just answering some common questions that aren’t answered on the [meteor site]
 
 **Table of Contents**
 
-	- [How do I update this FAQ?](#user-content-how-do-i-update-this-faq)
-	- [How can I find out more about Meteor?](#user-content-how-can-i-find-out-more-about-meteor)
+- [How do I update this FAQ?](#user-content-how-do-i-update-this-faq)
+- [How can I find out more about Meteor?](#user-content-how-can-i-find-out-more-about-meteor)
 - [Customizing Meteor](#user-content-customizing-meteor)
 	- [How do I use a preview release of meteor?](#user-content-how-do-i-use-a-preview-release-of-meteor)
 	- [How do I use a unreleased branch of meteor?](#user-content-how-do-i-use-a-unreleased-branch-of-meteor)


### PR DESCRIPTION
This Unofficial FAQ is great! So many useful questions.

With so many questions, it's a tad hard to read. This PR adds a **Table of Contents** to the top of the document.

Most of the work was done automatically by the free webapp [DocToc](http://doctoc.herokuapp.com/). See commit history for minor manual adjustments.
